### PR TITLE
删除presto依赖

### DIFF
--- a/orm.go
+++ b/orm.go
@@ -17,7 +17,6 @@ import (
 	"unicode"
 
 	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/avct/prestgo"
 	//"strconv"
 	"encoding/json"
 	"strconv"


### PR DESCRIPTION
go-orm中删掉presto依赖，因为用的比较少，在使用的工程里面再引入